### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.0.0
+* (Breaking changes)
+* Added more flexibility to the `BottomCupertinoTabbar` widget to define its own `BottomCupertinoTabItem` with custom widgets, instead of a single SVG string (thanks @nissaba). In this way, you can define your own icons with custom widgets.
+* Updated `tabbarModel` callback on `BottomCupertinoTabbar` main widget to expose nested navigator, in this way you can access the specific navigator of each tab.
+* Added `overrideIconsColor` flag to `BottomCupertinoTabbar` main widget to override the default icons color.
+* `activeColor` and `inactiveColor` properties are now optional, used in combination with `overrideIconsColor` flag.
+* Updated `BottomCupertinoTabItem`: now accepts new properties like single icon, active and inactive icons and active and inactive styles for labels.
+* Added more examples in the example app and updated the documentation.
+
 ## 1.0.13
 
 * Exposed some Scaffold properties to allow more customizations options. 

--- a/README.md
+++ b/README.md
@@ -91,20 +91,24 @@ Each tab is linked to a corresponding page and icon, with maintained state and n
 * **Custom Colors and Themes**: Customize the color scheme and theme to match your app's design. You can set colors for both the active and inactive states.
 * **Adjustable Size and Positioning**: The size and positioning of the tab bar and its elements can be adjusted to suit your layout needs.
 
-### `BottomCupertinoTabbar` Customization options
-| Properties                      | Description                                                                            |
-|---------------------------------|----------------------------------------------------------------------------------------|
-| activeColor                     | Color for the active tab icon and text                                                 |
-| inactiveColor                   | Color for the inactive tab icons and text.                                             |
-| notificationsBadgeColor         | Color for notification badges.                                                         |
-| firstActiveIndex                | Index of the initially active tab.                                                     |
-| resizeToAvoidBottomInset        | Resizes the bottom bar when the keyboard appears.                                      |
-| showLabels                      | Shows labels below icons.                                                              |
-| onTabPressed                    | Callback function for customizing tabs per index.                                      |
-| children                        | A list of BottomCupertinoTab widgets that represent each tab in the tab bar.           |
-| floatingActionButton            | An optional floating action button (or another widget) to be displayed on the tab bar. |
-| floatingActionButtonLocation    | The location of the floating action button on the tab bar.                             |
-| backgroundColor                 | The background color of the tab bar. Defaults to Colors.white.                         |
+### `BottomCupertinoTabbar` Main customization options
+| Properties                   | Description                                                                            |
+|------------------------------|----------------------------------------------------------------------------------------|
+| activeColor                  | Color for the active tab icon and text                                                 |
+| inactiveColor                | Color for the inactive tab icons and text.                                             |
+| notificationsBadgeColor      | Color for notification badges.                                                         |
+| firstActiveIndex             | Index of the initially active tab.                                                     |
+| resizeToAvoidBottomInset     | Resizes the bottom bar when the keyboard appears.                                      |
+| showLabels                   | Shows labels below icons.                                                              |
+| onTabPressed                 | Callback function for customizing tabs per index and accessing navigators.             |
+| children                     | A list of BottomCupertinoTab widgets that represent each tab in the tab bar.           |
+| floatingActionButton         | An optional floating action button (or another widget) to be displayed on the tab bar. |
+| floatingActionButtonLocation | The location of the floating action button on the tab bar.                             |
+| resizeToAvoidBottomInset     | Controls whether the bottom bar should resize when the on-screen keyboard appears.     |
+| backgroundColor              | The background color of the tab bar. Defaults to Colors.white.                         |
+| showLabels                   | Flag to control whether labels are shown on the tab items.                             |
+| appBar                       | Optional AppBar to be displayed at the top of the BottomCupertinoTabbar element.       |
+| overrideIconsColor           | Flag to control whether to override the color of the icons.                            |
 
 
 ## Tabs and State preservation
@@ -137,40 +141,53 @@ The `BottomCupertinoTabItem` class is used to configure the appearance and behav
 ```dart
 class BottomCupertinoTabItem {
 
-  final String? activeIcon;
-  final String? inactiveIcon;
+  /// The icon to display.
+  final Widget? icon;
+
+  /// The icon when the tab is active.
+  final Widget? activeIcon;
+
+  /// The icon when the tab is inactive.
+  final Widget? inactiveIcon;
+
+  /// The text label for the tab.
   final String? label;
+
+  /// The number of notifications to be displayed on the tab.
   final int notificationsCounter;
+
+  /// Controls whether to show the notifications counter.
   final bool showNotifications;
+
+  /// Indicates if the tab is to be considered as an empty placeholder.
   final bool empty;
 
+  /// The text style to use for the label when the tab is active.
+  final TextStyle? activeLabelTextStyle;
+
+  /// The text style to use for the label when the tab is inactive.
+  final TextStyle? inactiveLabelTextStyle;
+
   const BottomCupertinoTabItem({
+    this.icon,
     this.activeIcon,
     this.inactiveIcon,
     this.label,
     this.notificationsCounter = 0,
     this.showNotifications = false,
     this.empty = false,
+    this.activeLabelTextStyle,
+    this.inactiveLabelTextStyle,
   });
 }
 ```
-Parameters:
-* **activeIcon** (String?): The path for the icon to display when the tab is active.
-* **inactiveIcon** (String?): The path for the icon to display when the tab is inactive.
-* **label** (String?): The text label for the tab.
-* **notificationsCounter** (int): An integer value to show as a counter for notifications on the tab. Defaults to 0.
-* **showNotifications** (bool): A boolean to control the visibility of the notifications counter badge. Defaults to false.
-* **empty** (bool): A boolean to indicate if the tab should be considered as an empty placeholder. Defaults to false.
 
 Example of a `BottomCupertinoTab`
 ```dart
-const BottomCupertinoTab(
+BottomCupertinoTab(
   tab: BottomCupertinoTabItem(
-    activeIcon: "path/to/active_icon",
-    inactiveIcon: "path/to/inactive_icon",
+    icon: Icon(Icons.home, size: 22,),
     label: "Home",
-    notificationsCounter: 10,
-    showNotifications: true,
   ),
   page: HomePage(),
 )
@@ -190,16 +207,16 @@ import 'package:flutter/material.dart';
 import 'package:bottom_cupertino_tabbar/bottom_cupertino_tabbar.dart';
 
 import '../pages/pages.dart';
+import 'example_manager/example_manager.dart';
 
-class SimpleTabBar extends StatefulWidget {
-  const SimpleTabBar({super.key});
+class EasyTabbar extends StatefulWidget {
+  const EasyTabbar({super.key});
 
   @override
-  State<SimpleTabBar> createState() => _SimpleTabBarState();
+  State<EasyTabbar> createState() => _EasyTabbarState();
 }
 
-class _SimpleTabBarState extends State<SimpleTabBar> {
-
+class _EasyTabbarState extends State<EasyTabbar> {
   @override
   Widget build(BuildContext context) {
     return BottomCupertinoTabbar(
@@ -209,46 +226,48 @@ class _SimpleTabBarState extends State<SimpleTabBar> {
       firstActiveIndex: 0,
       resizeToAvoidBottomInset: false,
       showLabels: true,
+      overrideIconsColor: true,
+      tabbarModel: (model, nestedNavigator) {
+        ExampleManager().tabbarProviderModel = model;
+        ExampleManager().nestedNavigator = nestedNavigator;
+      },
       onTabPressed: (index, model, nestedNavigator) {
         if (index != model.currentTab) {
           model.changePage(index);
         } else {
           if (nestedNavigator[index]?.currentContext != null) {
-            Navigator.of(nestedNavigator[index]!.currentContext!).popUntil((route) => route.isFirst);
+            Navigator.of(nestedNavigator[index]!.currentContext!)
+                .popUntil((route) => route.isFirst);
           }
         }
       },
-      children: [
-        const BottomCupertinoTab(
+      children: const [
+        BottomCupertinoTab(
           tab: BottomCupertinoTabItem(
-            activeIcon: "assets/bottom/home.svg",
-            inactiveIcon: "assets/bottom/home.svg",
+            icon: Icon(Icons.home, size: 22,),
             label: "Home",
           ),
           page: HomePage(),
         ),
-        const BottomCupertinoTab(
+        BottomCupertinoTab(
           tab: BottomCupertinoTabItem(
-            activeIcon: "assets/bottom/bell.svg",
-            inactiveIcon: "assets/bottom/bell.svg",
+            icon: Icon(Icons.notifications, size: 22,),
             label: "Notifications",
           ),
           page: NotificationsPage(),
         ),
-        const BottomCupertinoTab(
+        BottomCupertinoTab(
           tab: BottomCupertinoTabItem(
-            activeIcon: "assets/bottom/contacts.svg",
-            inactiveIcon: "assets/bottom/contacts.svg",
+            icon: Icon(Icons.contacts, size: 22,),
             notificationsCounter: 4,
             showNotifications: true,
             label: "Contacts",
           ),
           page: ContactsPage(),
         ),
-        const BottomCupertinoTab(
+        BottomCupertinoTab(
           tab: BottomCupertinoTabItem(
-            activeIcon: "assets/bottom/settings.svg",
-            inactiveIcon: "assets/bottom/settings.svg",
+            icon: Icon(Icons.settings, size: 22,),
             label: "Settings",
           ),
           page: SettingsPage(),
@@ -258,6 +277,8 @@ class _SimpleTabBarState extends State<SimpleTabBar> {
   }
 }
 ```
+
+More examples can be found in the `example` folder of the package.
 
 ## Conclusion
 `BottomCupertinoTabbar` is an ideal choice for Flutter apps requiring a bottom navigation bar with advanced customization, including the addition of a floating action button or other widgets in various positions.

--- a/example/lib/easy_tabbar.dart
+++ b/example/lib/easy_tabbar.dart
@@ -4,22 +4,24 @@ import 'package:bottom_cupertino_tabbar/bottom_cupertino_tabbar.dart';
 import '../pages/pages.dart';
 import 'example_manager/example_manager.dart';
 
-class SimpleTabBar extends StatefulWidget {
-  const SimpleTabBar({super.key});
+class EasyTabbar extends StatefulWidget {
+  const EasyTabbar({super.key});
 
   @override
-  State<SimpleTabBar> createState() => _SimpleTabBarState();
+  State<EasyTabbar> createState() => _EasyTabbarState();
 }
 
-class _SimpleTabBarState extends State<SimpleTabBar> {
+class _EasyTabbarState extends State<EasyTabbar> {
   @override
   Widget build(BuildContext context) {
     return BottomCupertinoTabbar(
+      activeColor: Colors.blue,
+      inactiveColor: Colors.grey[300]!,
       notificationsBadgeColor: Colors.red,
       firstActiveIndex: 0,
       resizeToAvoidBottomInset: false,
       showLabels: true,
-      overrideIconsColor: false,
+      overrideIconsColor: true,
       tabbarModel: (model, nestedNavigator) {
         ExampleManager().tabbarProviderModel = model;
         ExampleManager().nestedNavigator = nestedNavigator;
@@ -37,75 +39,43 @@ class _SimpleTabBarState extends State<SimpleTabBar> {
       children: const [
         BottomCupertinoTab(
           tab: BottomCupertinoTabItem(
-            activeIcon: Icon(
+            icon: Icon(
               Icons.home,
               size: 22,
-              color: Colors.blue,
-            ),
-            inactiveIcon: Icon(
-              Icons.home_outlined,
-              size: 22,
-              color: Colors.grey,
             ),
             label: "Home",
-            activeLabelTextStyle: TextStyle(color: Colors.blue),
-            inactiveLabelTextStyle: TextStyle(color: Colors.grey),
           ),
           page: HomePage(),
         ),
         BottomCupertinoTab(
           tab: BottomCupertinoTabItem(
-            activeIcon: Icon(
+            icon: Icon(
               Icons.notifications,
               size: 22,
-              color: Colors.blue,
-            ),
-            inactiveIcon: Icon(
-              Icons.notifications_outlined,
-              size: 22,
-              color: Colors.grey,
             ),
             label: "Notifications",
-            activeLabelTextStyle: TextStyle(color: Colors.blue),
-            inactiveLabelTextStyle: TextStyle(color: Colors.grey),
           ),
           page: NotificationsPage(),
         ),
         BottomCupertinoTab(
           tab: BottomCupertinoTabItem(
-            activeIcon: Icon(
+            icon: Icon(
               Icons.contacts,
               size: 22,
-              color: Colors.blue,
-            ),
-            inactiveIcon: Icon(
-              Icons.contacts_outlined,
-              size: 22,
-              color: Colors.grey,
             ),
             notificationsCounter: 4,
             showNotifications: true,
             label: "Contacts",
-            activeLabelTextStyle: TextStyle(color: Colors.blue),
-            inactiveLabelTextStyle: TextStyle(color: Colors.grey),
           ),
           page: ContactsPage(),
         ),
         BottomCupertinoTab(
           tab: BottomCupertinoTabItem(
-            activeIcon: Icon(
+            icon: Icon(
               Icons.settings,
               size: 22,
-              color: Colors.blue,
-            ),
-            inactiveIcon: Icon(
-              Icons.settings_outlined,
-              size: 22,
-              color: Colors.grey,
             ),
             label: "Settings",
-            activeLabelTextStyle: TextStyle(color: Colors.blue),
-            inactiveLabelTextStyle: TextStyle(color: Colors.grey),
           ),
           page: SettingsPage(),
         ),

--- a/example/lib/example_manager/example_manager.dart
+++ b/example/lib/example_manager/example_manager.dart
@@ -1,4 +1,5 @@
 import 'package:bottom_cupertino_tabbar/bottom_cupertino_tabbar.dart';
+import 'package:flutter/material.dart';
 
 class ExampleManager {
   //singleton variables
@@ -11,4 +12,5 @@ class ExampleManager {
   }
 
   BottomCupertinoTabbarProviderModel? tabbarProviderModel;
+  Map<int, GlobalKey<NavigatorState>>? nestedNavigator;
 }

--- a/example/lib/main_page.dart
+++ b/example/lib/main_page.dart
@@ -2,6 +2,8 @@ import 'package:bottom_cupertino_tabbar_example/simple_tabbar.dart';
 import 'package:bottom_cupertino_tabbar_example/tabbar_with_centered_button.dart';
 import 'package:flutter/material.dart';
 
+import 'easy_tabbar.dart';
+
 class MainPage extends StatelessWidget {
   const MainPage({super.key});
 
@@ -11,31 +13,58 @@ class MainPage extends StatelessWidget {
       appBar: AppBar(
         title: const Text("Bottom Cupertino TabBar Examples"),
       ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            ElevatedButton(
-              onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (builder) => const SimpleTabBar(),
-                  ),
-                );
-              },
-              child: const Text("Simple TabBar"),
-            ),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (builder) => const TabBarWithCenteredButton(),
-                  ),
-                );
-              },
-              child: const Text("TabBar with centered button"),
-            ),
-          ],
+      body: Container(
+        margin: const EdgeInsets.fromLTRB(16, 0, 16, 0),
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.start,
+            children: [
+              const Text(
+                "Example with a simple icon widget and overriden colors inherited from tabbar",
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (builder) => const EasyTabbar(),
+                    ),
+                  );
+                },
+                child: const Text("Easy TabBar"),
+              ),
+              const SizedBox(height: 16),
+              const Text(
+                "Example with separate active and inactive icons widgets and label, each one with its own color and style",
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (builder) => const SimpleTabBar(),
+                    ),
+                  );
+                },
+                child: const Text("Simple TabBar"),
+              ),
+              const SizedBox(height: 16),
+              const Text(
+                "Example with separate active and inactive icons widgets, each one with its own color",
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (builder) => const TabBarWithCenteredButton(),
+                    ),
+                  );
+                },
+                child: const Text("TabBar with centered button"),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/example/lib/tabbar_with_centered_button.dart
+++ b/example/lib/tabbar_with_centered_button.dart
@@ -1,6 +1,7 @@
 import 'package:bottom_cupertino_tabbar_example/example_manager/example_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:bottom_cupertino_tabbar/bottom_cupertino_tabbar.dart';
+import 'package:flutter_svg/svg.dart';
 
 import '../pages/pages.dart';
 
@@ -16,14 +17,13 @@ class _TabBarWithCenteredButtonState extends State<TabBarWithCenteredButton> {
   @override
   Widget build(BuildContext context) {
     return BottomCupertinoTabbar(
-      activeColor: Colors.blue,
-      inactiveColor: Colors.grey[300]!,
       notificationsBadgeColor: Colors.red,
       firstActiveIndex: 0,
       resizeToAvoidBottomInset: false,
       showLabels: true,
-      tabbarModel: (model) {
+      tabbarModel: (model, nestedNavigator) {
         ExampleManager().tabbarProviderModel = model;
+        ExampleManager().nestedNavigator = nestedNavigator;
       },
       floatingActionButton: FloatingActionButton(
         onPressed: () {
@@ -55,43 +55,107 @@ class _TabBarWithCenteredButtonState extends State<TabBarWithCenteredButton> {
         }
       },
       children: [
-        const BottomCupertinoTab(
+        BottomCupertinoTab(
           tab: BottomCupertinoTabItem(
-            activeIcon: "assets/bottom/home.svg",
-            inactiveIcon: "assets/bottom/home.svg",
+            activeIcon: SvgPicture.asset(
+              "assets/bottom/home.svg",
+              height: 22,
+              colorFilter: const ColorFilter.mode(
+                Colors.blue,
+                BlendMode.srcIn,
+              ),
+            ),
+            inactiveIcon: SvgPicture.asset(
+              "assets/bottom/home.svg",
+              height: 22,
+              colorFilter: const ColorFilter.mode(
+                Colors.grey,
+                BlendMode.srcIn,
+              ),
+            ),
             label: "Home",
+            activeLabelTextStyle: const TextStyle(color: Colors.blue),
+            inactiveLabelTextStyle: const TextStyle(color: Colors.grey),
           ),
-          page: HomePage(),
-        ),
-        const BottomCupertinoTab(
-          tab: BottomCupertinoTabItem(
-            activeIcon: "assets/bottom/bell.svg",
-            inactiveIcon: "assets/bottom/bell.svg",
-            label: "Notifications",
-          ),
-          page: NotificationsPage(),
+          page: const HomePage(),
         ),
         BottomCupertinoTab(
-          tab: const BottomCupertinoTabItem(
-            empty: true,
+          tab: BottomCupertinoTabItem(
+            activeIcon: SvgPicture.asset(
+              "assets/bottom/bell.svg",
+              height: 22,
+              colorFilter: const ColorFilter.mode(
+                Colors.blue,
+                BlendMode.srcIn,
+              ),
+            ),
+            inactiveIcon: SvgPicture.asset(
+              "assets/bottom/bell.svg",
+              height: 22,
+              colorFilter: const ColorFilter.mode(
+                Colors.grey,
+                BlendMode.srcIn,
+              ),
+            ),
+            label: "Notifications",
+            activeLabelTextStyle: const TextStyle(color: Colors.blue),
+            inactiveLabelTextStyle: const TextStyle(color: Colors.grey),
           ),
-          page: const SizedBox.shrink(),
+          page: const NotificationsPage(),
         ),
         const BottomCupertinoTab(
           tab: BottomCupertinoTabItem(
-            activeIcon: "assets/bottom/contacts.svg",
-            inactiveIcon: "assets/bottom/contacts.svg",
+            empty: true,
+          ),
+          page: SizedBox.shrink(),
+        ),
+        BottomCupertinoTab(
+          tab: BottomCupertinoTabItem(
+            activeIcon: SvgPicture.asset(
+              "assets/bottom/contacts.svg",
+              height: 22,
+              colorFilter: const ColorFilter.mode(
+                Colors.blue,
+                BlendMode.srcIn,
+              ),
+            ),
+            inactiveIcon: SvgPicture.asset(
+              "assets/bottom/contacts.svg",
+              height: 22,
+              colorFilter: const ColorFilter.mode(
+                Colors.grey,
+                BlendMode.srcIn,
+              ),
+            ),
             notificationsCounter: 4,
             showNotifications: true,
             label: "Contacts",
+            activeLabelTextStyle: const TextStyle(color: Colors.blue),
+            inactiveLabelTextStyle: const TextStyle(color: Colors.grey),
           ),
-          page: ContactsPage(),
+          page: const ContactsPage(),
         ),
-        const BottomCupertinoTab(
+        BottomCupertinoTab(
           tab: BottomCupertinoTabItem(
-            activeIcon: "assets/bottom/settings.svg",
-            inactiveIcon: "assets/bottom/settings.svg",
+            activeIcon: SvgPicture.asset(
+              "assets/bottom/settings.svg",
+              height: 22,
+              colorFilter: const ColorFilter.mode(
+                Colors.blue,
+                BlendMode.srcIn,
+              ),
+            ),
+            inactiveIcon: SvgPicture.asset(
+              "assets/bottom/settings.svg",
+              height: 22,
+              colorFilter: const ColorFilter.mode(
+                Colors.grey,
+                BlendMode.srcIn,
+              ),
+            ),
             label: "Settings",
+            activeLabelTextStyle: const TextStyle(color: Colors.blue),
+            inactiveLabelTextStyle: const TextStyle(color: Colors.grey),
           ),
           page: SettingsPage(),
         ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -31,7 +31,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.13"
+    version: "2.0.0"
   characters:
     dependency: transitive
     description:
@@ -86,7 +86,7 @@ packages:
     source: hosted
     version: "4.0.0"
   flutter_svg:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: flutter_svg
       sha256: "7b4ca6cf3304575fe9c8ec64813c8d02ee41d2afe60bcfe0678bcb5375d596a2"
@@ -307,10 +307,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.2.5"
   web:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.8
+  flutter_svg: ^2.0.10+1
 
   bottom_cupertino_tabbar:
     path: ../

--- a/lib/src/bottom_cupertino_tabbar_base.dart
+++ b/lib/src/bottom_cupertino_tabbar_base.dart
@@ -11,10 +11,10 @@ import 'package:provider/provider.dart';
 /// It supports custom tab items, nested navigation, and optional floating action buttons.
 class BottomCupertinoTabbar extends StatefulWidget {
   /// The color used for active tab items.
-  final Color activeColor;
+  final Color? activeColor;
 
   /// The color used for inactive tab items.
-  final Color inactiveColor;
+  final Color? inactiveColor;
 
   /// The color of notification badges on tab items.
   final Color notificationsBadgeColor;
@@ -31,7 +31,8 @@ class BottomCupertinoTabbar extends StatefulWidget {
       Map<int, GlobalKey<NavigatorState>>) onTabPressed;
 
   /// A function that returns a model to manage the state and behavior of the BottomCupertinoTabbar.
-  final Function(BottomCupertinoTabbarProviderModel)? tabbarModel;
+  final Function(BottomCupertinoTabbarProviderModel,
+      Map<int, GlobalKey<NavigatorState>>)? tabbarModel;
 
   /// An optional floating action button to be displayed alongside the tab bar.
   final Widget? floatingActionButton;
@@ -64,11 +65,14 @@ class BottomCupertinoTabbar extends StatefulWidget {
   final bool endDrawerEnableOpenDragGesture;
   final String? restorationId;
 
+  /// Flag to control whether to override the color of the icons.
+  final bool overrideIconsColor;
+
   /// Constructs a BottomCupertinoTabbar.
   const BottomCupertinoTabbar({
     super.key,
-    required this.activeColor,
-    required this.inactiveColor,
+    this.activeColor,
+    this.inactiveColor,
     required this.notificationsBadgeColor,
     required this.firstActiveIndex,
     required this.children,
@@ -91,6 +95,7 @@ class BottomCupertinoTabbar extends StatefulWidget {
     this.drawerEnableOpenDragGesture = true,
     this.endDrawerEnableOpenDragGesture = true,
     this.restorationId,
+    this.overrideIconsColor = false,
   });
 
   @override
@@ -143,9 +148,10 @@ class _BottomCupertinoTabbarState extends State<BottomCupertinoTabbar> {
       for (int i = 0; i < pages.length; i++) {
         var child = pages[i];
         var indexedWidget = ItemChild(
-            key: ValueKey(i),
-            navigatorKey: nestedNavigator[i],
-            child: child.page);
+          key: ValueKey(i),
+          navigatorKey: nestedNavigator[i],
+          child: child.page,
+        );
         _cachedChildren!.add(indexedWidget);
       }
     }
@@ -159,7 +165,7 @@ class _BottomCupertinoTabbarState extends State<BottomCupertinoTabbar> {
       child: Consumer<BottomCupertinoTabbarProviderModel>(
         builder: (context, model, child) {
           if (widget.tabbarModel != null) {
-            widget.tabbarModel!(model);
+            widget.tabbarModel!(model, _nestedNavigator);
           }
           var currentTab = model.currentTab;
           return NavigatorPopHandler(
@@ -193,11 +199,14 @@ class _BottomCupertinoTabbarState extends State<BottomCupertinoTabbar> {
                 onTabPressed: widget.onTabPressed,
                 showLabels: widget.showLabels,
                 backgroundColor: widget.backgroundColor,
+                overrideIconsColor: widget.overrideIconsColor,
               ),
               body: IndexedStack(
                 index: currentTab,
                 children: _getChildren(
-                    pages: widget.children, nestedNavigator: _nestedNavigator),
+                  pages: widget.children,
+                  nestedNavigator: _nestedNavigator,
+                ),
               ),
             ),
           );

--- a/lib/src/tabbar_components/bottom_bar.dart
+++ b/lib/src/tabbar_components/bottom_bar.dart
@@ -18,10 +18,10 @@ class BottomBar extends StatefulWidget {
   final BottomCupertinoTabbarProviderModel model;
 
   /// Color for active tab items.
-  final Color activeColor;
+  final Color? activeColor;
 
   /// Color for inactive tab items.
-  final Color inactiveColor;
+  final Color? inactiveColor;
 
   /// Color for notification badges on the tab items.
   final Color notificationsBadgeColor;
@@ -40,7 +40,11 @@ class BottomBar extends StatefulWidget {
   /// Flag to show or hide labels under tab icons.
   final bool showLabels;
 
+  /// Background color for the bottom navigation bar.
   final Color? backgroundColor;
+
+  /// Flag to control whether to override the color of the icons.
+  final bool overrideIconsColor;
 
   /// Constructor for BottomBar.
   const BottomBar({
@@ -55,6 +59,7 @@ class BottomBar extends StatefulWidget {
     required this.onTabPressed,
     this.showLabels = false,
     this.backgroundColor,
+    required this.overrideIconsColor,
   });
 
   @override
@@ -77,8 +82,9 @@ class _BottomBarState extends State<BottomBar> {
       if (!bottomCupertinoTab.tab.empty) {
         bool isActive = widget.model.currentTab == i;
         final tab = TabItem(
-          activeIcon: bottomCupertinoTab.tab.activeIcon!,
-          inactiveIcon: bottomCupertinoTab.tab.inactiveIcon!,
+          icon: bottomCupertinoTab.tab.icon,
+          activeIcon: bottomCupertinoTab.tab.activeIcon,
+          inactiveIcon: bottomCupertinoTab.tab.inactiveIcon,
           label: bottomCupertinoTab.tab.label,
           showNotifications: bottomCupertinoTab.tab.showNotifications,
           notificationsCounter: bottomCupertinoTab.tab.notificationsCounter,
@@ -88,6 +94,9 @@ class _BottomBarState extends State<BottomBar> {
           active: isActive,
           isFirstActiveIndex: widget.firstActiveIndex == i,
           showLabels: widget.showLabels,
+          overrideIconsColor: widget.overrideIconsColor,
+          activeLabelTextStyle: bottomCupertinoTab.tab.activeLabelTextStyle,
+          inactiveLabelTextStyle: bottomCupertinoTab.tab.inactiveLabelTextStyle,
         );
         results.add(BottomNavigationBarItem(icon: tab));
       } else {

--- a/lib/src/tabbar_components/icon_component.dart
+++ b/lib/src/tabbar_components/icon_component.dart
@@ -1,35 +1,81 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/svg.dart';
 
 class IconComponent extends StatelessWidget {
+  /// Indicates whether the icon is in the active state.
   final bool active;
-  final String activeIcon;
-  final String inactiveIcon;
-  final Color activeColor;
-  final Color inactiveColor;
 
+  /// The icon to display.
+  final Widget? icon;
+
+  /// The icon to display when the component is active.
+  final Widget? activeIcon;
+
+  /// The icon to display when the component is inactive.
+  final Widget? inactiveIcon;
+
+  /// The color to use for the icon when the component is active.
+  final Color? activeColor;
+
+  /// The color to use for the icon when the component is inactive.
+  final Color? inactiveColor;
+
+  /// A flag to control whether to override the color of the icons.
+  final bool overrideIconsColor;
+
+  /// Creates an [IconComponent] widget.
+  ///
+  /// An assertion ensures that either [icon] with [overrideIconsColor] set to true and both [activeColor] and [inactiveColor] are provided,
+  /// or both [activeIcon] and [inactiveIcon] are provided.
   const IconComponent({
     super.key,
     required this.active,
-    required this.activeIcon,
-    required this.inactiveIcon,
+    this.icon,
+    this.activeIcon,
+    this.inactiveIcon,
     required this.activeColor,
     required this.inactiveColor,
-  });
+    required this.overrideIconsColor,
+  }) : assert(
+          (icon != null &&
+                  overrideIconsColor == true &&
+                  activeColor != null &&
+                  inactiveColor != null) ||
+              (activeIcon != null && inactiveIcon != null),
+          'Provide either icon with overrideIconColor set to true, or both activeIcon and inactiveIcon.',
+        );
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      height: 22,
-      width: 22,
-      child: SvgPicture.asset(
-        active ? activeIcon : inactiveIcon,
+    Widget child;
+    if (activeIcon != null && inactiveIcon != null) {
+      child = active ? activeIcon! : inactiveIcon!;
+    } else if (icon != null) {
+      child = icon!;
+    } else {
+      return const SizedBox.shrink();
+    }
+
+    if (overrideIconsColor && activeColor != null && inactiveColor != null) {
+      final Color tintColor = active ? activeColor! : inactiveColor!;
+
+      return SizedBox(
         height: 22,
-        colorFilter: ColorFilter.mode(
-          active ? activeColor : inactiveColor,
-          BlendMode.srcIn,
+        width: 22,
+        child: ColorFiltered(
+          colorFilter: ColorFilter.mode(
+            tintColor,
+            BlendMode.srcIn,
+          ),
+          child: child,
         ),
-      ),
-    );
+      );
+    } else {
+      // No color override; return the original icon
+      return SizedBox(
+        height: 22,
+        width: 22,
+        child: child,
+      );
+    }
   }
 }

--- a/lib/src/tabbar_components/label_component.dart
+++ b/lib/src/tabbar_components/label_component.dart
@@ -1,27 +1,65 @@
 import 'package:flutter/material.dart';
 
 class LabelComponent extends StatelessWidget {
+  /// The text label of the component.
   final String label;
-  final bool active;
-  final Color activeColor;
-  final Color inactiveColor;
 
+  /// Indicates whether the component is currently active.
+  final bool active;
+
+  /// The color to use for the label when the component is active.
+  final Color? activeColor;
+
+  /// The color to use for the label when the component is inactive.
+  final Color? inactiveColor;
+
+  /// The text style to use for the label when the component is active.
+  final TextStyle? activeLabelTextStyle;
+
+  /// The text style to use for the label when the component is inactive.
+  final TextStyle? inactiveLabelTextStyle;
+
+  /// Creates a [LabelComponent] widget.
+  ///
+  /// Assertions ensure that either both [activeLabelTextStyle] and [inactiveLabelTextStyle] are provided,
+  /// or both [activeColor] and [inactiveColor] are provided, but not both.
   const LabelComponent({
     super.key,
     required this.label,
     required this.active,
     required this.activeColor,
     required this.inactiveColor,
-  });
+    this.activeLabelTextStyle,
+    this.inactiveLabelTextStyle,
+  })  : assert(
+          (activeLabelTextStyle != null && inactiveLabelTextStyle != null) ||
+              (activeColor != null && inactiveColor != null),
+          'Either provide activeLabelTextStyle and inactiveLabelTextStyle, or activeColor and inactiveColor.',
+        ),
+        assert(
+          (activeLabelTextStyle == null && inactiveLabelTextStyle == null) ||
+              (activeColor == null && inactiveColor == null),
+          'Cannot provide both label text styles and label colors. Choose one.',
+        );
 
   @override
   Widget build(BuildContext context) {
+    final TextStyle textStyle;
+    if (activeLabelTextStyle != null && inactiveLabelTextStyle != null) {
+      textStyle = active ? activeLabelTextStyle! : inactiveLabelTextStyle!;
+    } else if (activeColor != null && inactiveColor != null) {
+      textStyle = TextStyle(
+        color: active ? activeColor : inactiveColor,
+        fontSize: 11,
+      );
+    } else {
+      textStyle = const TextStyle(fontSize: 11);
+    }
     return Container(
       margin: const EdgeInsets.fromLTRB(0, 4, 0, 0),
       child: Text(
         label,
-        style: TextStyle(
-            color: active ? activeColor : inactiveColor, fontSize: 11),
+        style: textStyle,
       ),
     );
   }

--- a/lib/src/tabbar_components/label_icon_component.dart
+++ b/lib/src/tabbar_components/label_icon_component.dart
@@ -4,22 +4,62 @@ import 'package:flutter/material.dart';
 import 'icon_component.dart';
 
 class LabelIconComponent extends StatelessWidget {
+  /// Indicates whether the tab is currently active.
   final bool active;
-  final String activeIcon;
-  final String inactiveIcon;
-  final Color activeColor;
-  final Color inactiveColor;
+
+  /// The icon to display.
+  final Widget? icon;
+
+  /// The icon to display when the tab is active.
+  final Widget? activeIcon;
+
+  /// The icon to display when the tab is inactive.
+  final Widget? inactiveIcon;
+
+  /// The color to use for the active state of the tab (icon and text).
+  final Color? activeColor;
+
+  /// The color to use for the inactive state of the tab (icon and text).
+  final Color? inactiveColor;
+
+  /// The text label of the tab. It's optional and only displayed if [showLabels] is true.
   final String label;
 
+  /// A flag to control whether to override the color of the icons.
+  final bool overrideIconsColor;
+
+  /// The text style to use for the label when the tab is active.
+  final TextStyle? activeLabelTextStyle;
+
+  /// The text style to use for the label when the tab is inactive.
+  final TextStyle? inactiveLabelTextStyle;
+
+  /// Creates a [LabelIconComponent] widget.
+  ///
+  /// Assertions ensure that either both [activeLabelTextStyle] and [inactiveLabelTextStyle] are provided,
+  /// or both [activeColor] and [inactiveColor] are provided, but not both.
   const LabelIconComponent({
     super.key,
     required this.active,
+    this.icon,
     required this.activeIcon,
     required this.inactiveIcon,
     required this.activeColor,
     required this.inactiveColor,
     required this.label,
-  });
+    required this.overrideIconsColor,
+    this.activeLabelTextStyle,
+    this.inactiveLabelTextStyle,
+  })  : assert(
+          (activeLabelTextStyle != null && inactiveLabelTextStyle != null) ||
+              (activeColor != null && inactiveColor != null),
+          'Either provide activeLabelTextStyle and inactiveLabelTextStyle, or activeColor and inactiveColor.',
+        ),
+        assert(
+          (activeLabelTextStyle == null && inactiveLabelTextStyle == null) ||
+              (activeColor == null && inactiveColor == null),
+          'Cannot provide both label text styles and label colors. Choose one.',
+        );
 
   @override
   Widget build(BuildContext context) {
@@ -32,17 +72,22 @@ class LabelIconComponent extends StatelessWidget {
           // The icon itself, using an SVG image.
           IconComponent(
             active: active,
+            icon: icon,
             activeIcon: activeIcon,
             inactiveIcon: inactiveIcon,
             activeColor: activeColor,
             inactiveColor: inactiveColor,
+            overrideIconsColor: overrideIconsColor,
           ),
           // The label text positioned below the icon.
           LabelComponent(
-              label: label,
-              active: active,
-              activeColor: activeColor,
-              inactiveColor: inactiveColor),
+            label: label,
+            active: active,
+            activeColor: activeColor,
+            inactiveColor: inactiveColor,
+            activeLabelTextStyle: activeLabelTextStyle,
+            inactiveLabelTextStyle: inactiveLabelTextStyle,
+          ),
         ],
       ),
     );

--- a/lib/src/tabbar_components/tab_inner_item.dart
+++ b/lib/src/tabbar_components/tab_inner_item.dart
@@ -4,23 +4,52 @@ import 'icon_component.dart';
 import 'label_icon_component.dart';
 
 class TabInnerItem extends StatelessWidget {
+  /// Indicates whether the tab is currently active.
   final bool active;
-  final String activeIcon;
-  final String inactiveIcon;
-  final Color activeColor;
-  final Color inactiveColor;
+
+  /// The icon to display.
+  final Widget? icon;
+
+  /// The icon to display when the tab is active.
+  final Widget? activeIcon;
+
+  /// The icon to display when the tab is inactive.
+  final Widget? inactiveIcon;
+
+  /// The color to use for the active state of the tab (icon and text).
+  final Color? activeColor;
+
+  /// The color to use for the inactive state of the tab (icon and text).
+  final Color? inactiveColor;
+
+  /// The text label of the tab. It's optional and only displayed if [showLabels] is true.
   final String? label;
+
+  /// A flag to control whether to show the label under the icon.
   final bool showLabels;
+
+  /// A flag to control whether to override the color of the icons.
+  final bool overrideIconsColor;
+
+  /// The text style to use for the label when the tab is active.
+  final TextStyle? activeLabelTextStyle;
+
+  /// The text style to use for the label when the tab is inactive.
+  final TextStyle? inactiveLabelTextStyle;
 
   const TabInnerItem({
     super.key,
     required this.active,
+    this.icon,
     required this.activeIcon,
     required this.inactiveIcon,
     required this.activeColor,
     required this.inactiveColor,
     this.label,
     this.showLabels = false,
+    required this.overrideIconsColor,
+    this.activeLabelTextStyle,
+    this.inactiveLabelTextStyle,
   });
 
   @override
@@ -30,23 +59,30 @@ class TabInnerItem extends StatelessWidget {
       // When showing labels, the icon and label are arranged in a column.
       result = LabelIconComponent(
         active: active,
+        icon: icon,
         activeIcon: activeIcon,
         inactiveIcon: inactiveIcon,
         activeColor: activeColor,
         inactiveColor: inactiveColor,
         label: label!,
+        overrideIconsColor: overrideIconsColor,
+        activeLabelTextStyle: activeLabelTextStyle,
+        inactiveLabelTextStyle: inactiveLabelTextStyle,
       );
     } else {
       // When not showing labels, only display the icon.
       result = Positioned(
-          top: 16,
-          child: IconComponent(
-            active: active,
-            activeIcon: activeIcon,
-            inactiveIcon: inactiveIcon,
-            activeColor: activeColor,
-            inactiveColor: inactiveColor,
-          ));
+        top: 16,
+        child: IconComponent(
+          active: active,
+          icon: icon,
+          activeIcon: activeIcon,
+          inactiveIcon: inactiveIcon,
+          activeColor: activeColor,
+          inactiveColor: inactiveColor,
+          overrideIconsColor: overrideIconsColor,
+        ),
+      );
     }
     return result;
   }

--- a/lib/src/tabbar_components/tab_item.dart
+++ b/lib/src/tabbar_components/tab_item.dart
@@ -6,11 +6,14 @@ import 'notifications_badge.dart';
 /// TabItem is a StatelessWidget used for rendering a single tab in a tab bar.
 /// It supports active/inactive states, labels, notification badges, and custom coloring.
 class TabItem extends StatelessWidget {
-  /// The asset path of the icon when the tab is active.
-  final String activeIcon;
+  /// The icon to display.
+  final Widget? icon;
 
-  /// The asset path of the icon when the tab is inactive.
-  final String inactiveIcon;
+  /// The icon when the tab is active.
+  final Widget? activeIcon;
+
+  /// The icon when the tab is inactive.
+  final Widget? inactiveIcon;
 
   /// The label text of the tab. It's optional and only displayed if [showLabels] is true.
   final String? label;
@@ -25,10 +28,10 @@ class TabItem extends StatelessWidget {
   final bool isFirstActiveIndex;
 
   /// The color to use for the active state of the tab (icon and text).
-  final Color activeColor;
+  final Color? activeColor;
 
   /// The color to use for the inactive state of the tab (icon and text).
-  final Color inactiveColor;
+  final Color? inactiveColor;
 
   /// The color of the notifications badge.
   final Color notificationsBadgeColor;
@@ -39,9 +42,19 @@ class TabItem extends StatelessWidget {
   /// A flag to control whether to show the label under the icon.
   final bool showLabels;
 
+  /// A flag to control whether to override the color of the icons.
+  final bool overrideIconsColor;
+
+  /// The text style to use for the label when the tab is active.
+  final TextStyle? activeLabelTextStyle;
+
+  /// The text style to use for the label when the tab is inactive.
+  final TextStyle? inactiveLabelTextStyle;
+
   /// Constructor for TabItem.
   const TabItem({
     super.key,
+    this.icon,
     required this.activeIcon,
     required this.inactiveIcon,
     required this.label,
@@ -53,6 +66,9 @@ class TabItem extends StatelessWidget {
     required this.notificationsBadgeColor,
     this.showNotifications = false,
     this.showLabels = false,
+    required this.overrideIconsColor,
+    this.activeLabelTextStyle,
+    this.inactiveLabelTextStyle,
   });
 
   @override
@@ -62,12 +78,16 @@ class TabItem extends StatelessWidget {
       children: [
         TabInnerItem(
           active: active,
+          icon: icon,
           activeIcon: activeIcon,
           inactiveIcon: inactiveIcon,
           activeColor: activeColor,
           inactiveColor: inactiveColor,
           label: label,
           showLabels: showLabels,
+          overrideIconsColor: overrideIconsColor,
+          activeLabelTextStyle: activeLabelTextStyle,
+          inactiveLabelTextStyle: inactiveLabelTextStyle,
         ),
         NotificationsBadge(
           showNotifications: showNotifications,

--- a/lib/src/tabbar_models/bottom_cupertino_tab_item.dart
+++ b/lib/src/tabbar_models/bottom_cupertino_tab_item.dart
@@ -18,11 +18,14 @@ class BottomCupertinoTab {
 
 /// BottomCupertinoTabItem holds the configuration for a tab in the BottomCupertinoTabbar.
 class BottomCupertinoTabItem {
-  /// The path or identifier for the icon when the tab is active.
-  final String? activeIcon;
+  /// The single icon to display.
+  final Widget? icon;
 
-  /// The path or identifier for the icon when the tab is inactive.
-  final String? inactiveIcon;
+  /// The icon when the tab is active.
+  final Widget? activeIcon;
+
+  /// The icon when the tab is inactive.
+  final Widget? inactiveIcon;
 
   /// The text label for the tab.
   final String? label;
@@ -36,20 +39,21 @@ class BottomCupertinoTabItem {
   /// Indicates if the tab is to be considered as an empty placeholder.
   final bool empty;
 
-  /// Constructs a BottomCupertinoTabItem with various customization options.
-  ///
-  /// [activeIcon]: Path for the active state icon.
-  /// [inactiveIcon]: Path for the inactive state icon.
-  /// [label]: Text label for the tab.
-  /// [notificationsCounter]: Counter for notifications, displayed as a badge.
-  /// [showNotifications]: Whether to show the notifications badge.
-  /// [empty]: Whether the tab is an empty placeholder, useful for custom layouts.
+  /// The text style to use for the label when the tab is active.
+  final TextStyle? activeLabelTextStyle;
+
+  /// The text style to use for the label when the tab is inactive.
+  final TextStyle? inactiveLabelTextStyle;
+
   const BottomCupertinoTabItem({
+    this.icon,
     this.activeIcon,
     this.inactiveIcon,
     this.label,
     this.notificationsCounter = 0,
     this.showNotifications = false,
     this.empty = false,
+    this.activeLabelTextStyle,
+    this.inactiveLabelTextStyle,
   });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bottom_cupertino_tabbar
 description: "BottomCupertinoTabbar is a customizable, Cupertino-style Flutter widget for bottom navigation with support for individual navigation stacks per tab."
-version: 1.0.13
+version: 2.0.0
 homepage: https://github.com/iJack93/bottom_cupertino_tabbar
 
 environment:


### PR DESCRIPTION
- Added more flexibility to the `BottomCupertinoTabbar` widget to define its own `BottomCupertinoTabItem` with custom widgets, instead of a single SVG string (thanks @nissaba). In this way, you can define your own icons with custom widgets.
- Updated `tabbarModel` callback on `BottomCupertinoTabbar` main widget to expose nested navigator, in this way you can access the specific navigator of each tab.
- Added `overrideIconsColor` flag to `BottomCupertinoTabbar` main widget to override the default icons color.
- `activeColor` and `inactiveColor` properties are now optional, used in combination with `overrideIconsColor` flag.
- Updated `BottomCupertinoTabItem`: now accepts new properties like single icon, active and inactive icons and active and inactive styles for labels.
- Added more examples in the example app and updated the documentation.