### PR TITLE
Fix onPopWithResult bug.

### DIFF
--- a/lib/src/bottom_cupertino_tabbar_base.dart
+++ b/lib/src/bottom_cupertino_tabbar_base.dart
@@ -173,10 +173,6 @@ class _BottomCupertinoTabbarState extends State<BottomCupertinoTabbar> {
           }
           var currentTab = model.currentTab;
           return NavigatorPopHandler(
-            onPopWithResult: (result) async {
-              await _onPopInvoked(
-                  currentTab); // ignore `result` if you don’t need it
-            },
             child: Scaffold(
               backgroundColor: widget.backgroundColor,
               resizeToAvoidBottomInset: widget.resizeToAvoidBottomInset,


### PR DESCRIPTION
When I run the code the first time there was this error: 
Running Gradle task 'assembleDebug'...
../../../.pub-cache/hosted/pub.dev/bottom_cupertino_tabbar-2.0.1/lib/src/bottom_cupertino_tabbar_base.dart:176:13: Error: No named parameter with the name 'onPopWithResult'.
            onPopWithResult: (result) async {
            ^^^^^^^^^^^^^^^
../../Development/flutter/packages/flutter/lib/src/widgets/navigator_pop_handler.dart:38:9: Context: Found this candidate, but the arguments don't match.
  const NavigatorPopHandler({
        ^^^^^^^^^^^^^^^^^^^
Target kernel_snapshot_program failed: Exception. 

So, I removed it and now it works.